### PR TITLE
Go version update 1.16

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: git checkout
         uses: actions/checkout@v2
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,5 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
-before:
-  hooks:
-    # this is just an example and not a requirement for provider building/publishing
-    - go mod tidy
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/sHesl/terraform-provider-imagesync
+module github.com/ravelin-community/terraform-provider-imagesync
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go/storage v1.8.0 // indirect

--- a/imagesync/resource_imagesync_test.go
+++ b/imagesync/resource_imagesync_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/sHesl/terraform-provider-imagesync/imagesync"
+	"github.com/ravelin-community/terraform-provider-imagesync/imagesync"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry" // Modified to allow registry deletes

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/sHesl/terraform-provider-imagesync/imagesync"
+	"github.com/ravelin-community/terraform-provider-imagesync/imagesync"
 )
 
 func main() {


### PR DESCRIPTION
Forking imagesync and updating go from 1.14 to 1.16 to have darwin arm64 support.